### PR TITLE
Spark 3.3.2 fork with K8s / Iceberg support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Spark is built using [Apache Maven](https://maven.apache.org/).
 To build Spark and its example programs, run:
 
 ```bash
-./build/mvn -DskipTests clean package
+./build/mvn -DskipTests -Pkubernetes -Phadoop-cloud -Phive -Phive-thriftserver -Daws.java.sdk.version=1.11.788 clean package
 ```
 
 (You do not need to do this if you downloaded a pre-built package.)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Spark is built using [Apache Maven](https://maven.apache.org/).
 To build Spark and its example programs, run:
 
 ```bash
-./build/mvn -DskipTests -Pkubernetes -Phadoop-cloud -Phive -Phive-thriftserver -Daws.java.sdk.version=1.11.788 clean package
+./build/mvn -DskipTests -Pkubernetes -Phadoop-cloud -Phive -Phive-thriftserver clean package
 ```
 
 (You do not need to do this if you downloaded a pre-built package.)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Spark is built using [Apache Maven](https://maven.apache.org/).
 To build Spark and its example programs, run:
 
 ```bash
-./build/mvn -DskipTests -Pkubernetes -Phadoop-cloud -Phive -Phive-thriftserver clean package
+./build/mvn -DskipTests -Pkubernetes -Phive -Phive-thriftserver clean package
 ```
 
 (You do not need to do this if you downloaded a pre-built package.)

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -324,16 +324,22 @@ private[spark] class SparkSubmit extends Logging {
         // For example we might use the dependencies for downloading
         // files from a Hadoop Compatible fs e.g. S3. In this case the user might pass:
         // --packages com.amazonaws:aws-java-sdk:1.7.4:org.apache.hadoop:hadoop-aws:2.7.6
-        if (isKubernetesClusterModeDriver) {
-          val loader = getSubmitClassLoader(sparkConf)
-          for (jar <- resolvedMavenCoordinates) {
-            addJarToClasspath(jar, loader)
-          }
-        } else if (isKubernetesCluster) {
+        if (isKubernetesCluster) {
           // We need this in K8s cluster mode so that we can upload local deps
           // via the k8s application, like in cluster mode driver
-          childClasspath ++= resolvedMavenCoordinates
+          childClasspath ++= resolvedMavenCoordinates.split(",")
         } else {
+          // In K8s client mode, when in the driver, add resolved jars early as we might need
+          // them at the submit time for artifact downloading.
+          // For example we might use the dependencies for downloading
+          // files from a Hadoop Compatible fs e.g. S3. In this case the user might pass:
+          // --packages com.amazonaws:aws-java-sdk:1.7.4:org.apache.hadoop:hadoop-aws:2.7.6
+          if (isKubernetesClusterModeDriver) {
+            val loader = getSubmitClassLoader(sparkConf)
+            for (jar <- resolvedMavenCoordinates.split(",")) {
+              addJarToClasspath(jar, loader)
+            }
+          }
           args.jars = mergeFileLists(args.jars, mergeFileLists(resolvedMavenCoordinates: _*))
           if (args.isPython || isInternal(args.primaryResource)) {
             args.pyFiles = mergeFileLists(args.pyFiles,

--- a/pom.xml
+++ b/pom.xml
@@ -418,10 +418,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk-bundle</artifactId>
-      <version>${aws.java.sdk.version}</version>
-      <scope>runtime</scope>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>bundle</artifactId>
+      <version>2.20.79</version>
     </dependency>
   </dependencies>
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,7 @@
     <!-- managed up from 3.2.1 for SPARK-11652 -->
     <commons.collections.version>3.2.2</commons.collections.version>
     <commons.collections4.version>4.4</commons.collections4.version>
-    <scala.version>2.12.15</scala.version>
+    <scala.version>2.12.14</scala.version>
     <scala.binary.version>2.12</scala.binary.version>
     <scalatest-maven-plugin.version>2.0.2</scalatest-maven-plugin.version>
     <!--
@@ -421,6 +421,12 @@
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>bundle</artifactId>
       <version>2.20.79</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.iceberg</groupId>
+      <artifactId>iceberg-spark-runtime-3.3_2.12</artifactId>
+      <version>1.2.1</version>
+      <scope>runtime</scope>
     </dependency>
   </dependencies>
   <dependencyManagement>
@@ -3536,7 +3542,7 @@
          SPARK-34774 Add this property to ensure change-scala-version.sh can replace the public `scala.version`
          property correctly.
         -->
-        <scala.version>2.12.15</scala.version>
+        <scala.version>2.12.14</scala.version>
       </properties>
       <build>
         <pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,7 @@
     <!-- managed up from 3.2.1 for SPARK-11652 -->
     <commons.collections.version>3.2.2</commons.collections.version>
     <commons.collections4.version>4.4</commons.collections4.version>
-    <scala.version>2.12.14</scala.version>
+    <scala.version>2.12.15</scala.version>
     <scala.binary.version>2.12</scala.binary.version>
     <scalatest-maven-plugin.version>2.0.2</scalatest-maven-plugin.version>
     <!--
@@ -2736,16 +2736,6 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
-<!--  <dependencies>-->
-<!--    <dependency>-->
-<!--      <groupId>software.amazon.awssdk</groupId>-->
-<!--      <artifactId>aws-sdk-java</artifactId>-->
-<!--    </dependency>-->
-<!--    <dependency>-->
-<!--      <groupId>software.amazon.awssdk</groupId>-->
-<!--      <artifactId>s3</artifactId>-->
-<!--    </dependency>-->
-<!--  </dependencies>-->
   <build>
     <pluginManagement>
       <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -417,6 +417,12 @@
       <artifactId>junit-interface</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-bundle</artifactId>
+      <version>${aws.java.sdk.version}</version>
+      <scope>runtime</scope>
+    </dependency>
   </dependencies>
   <dependencyManagement>
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -420,12 +420,17 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>bundle</artifactId>
-      <version>2.20.79</version>
+      <version>2.20.83</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-aws</artifactId>
+      <version>3.3.2</version>
     </dependency>
     <dependency>
       <groupId>org.apache.iceberg</groupId>
       <artifactId>iceberg-spark-runtime-3.3_2.12</artifactId>
-      <version>1.2.1</version>
+      <version>1.3.0</version>
       <scope>runtime</scope>
     </dependency>
   </dependencies>
@@ -2731,7 +2736,16 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
-
+<!--  <dependencies>-->
+<!--    <dependency>-->
+<!--      <groupId>software.amazon.awssdk</groupId>-->
+<!--      <artifactId>aws-sdk-java</artifactId>-->
+<!--    </dependency>-->
+<!--    <dependency>-->
+<!--      <groupId>software.amazon.awssdk</groupId>-->
+<!--      <artifactId>s3</artifactId>-->
+<!--    </dependency>-->
+<!--  </dependencies>-->
   <build>
     <pluginManagement>
       <plugins>
@@ -3542,7 +3556,7 @@
          SPARK-34774 Add this property to ensure change-scala-version.sh can replace the public `scala.version`
          property correctly.
         -->
-        <scala.version>2.12.14</scala.version>
+        <scala.version>2.12.15</scala.version>
       </properties>
       <build>
         <pluginManagement>

--- a/python/.gitignore
+++ b/python/.gitignore
@@ -3,3 +3,4 @@ docs/_build/
 pyspark.egg-info
 build/
 dist/
+venv/

--- a/python/MANIFEST.in
+++ b/python/MANIFEST.in
@@ -17,6 +17,7 @@
 global-exclude *.py[cod] __pycache__ .DS_Store
 recursive-include deps/jars *.jar
 graft deps/bin
+graft deps/k8s
 recursive-include deps/sbin spark-config.sh spark-daemon.sh start-history-server.sh stop-history-server.sh
 recursive-include deps/data *.data *.txt
 recursive-include deps/licenses *.txt

--- a/python/pyspark/version.py
+++ b/python/pyspark/version.py
@@ -16,4 +16,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__: str = "3.3.2+affirm.dev8"
+__version__: str = "3.3.2+affirm.dev10"

--- a/python/pyspark/version.py
+++ b/python/pyspark/version.py
@@ -16,4 +16,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__: str = "3.3.3.dev0"
+__version__: str = "3.3.2+affirm.dev5"

--- a/python/pyspark/version.py
+++ b/python/pyspark/version.py
@@ -16,4 +16,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__: str = "3.3.2+affirm.dev5"
+__version__: str = "3.3.2+affirm.dev6"

--- a/python/pyspark/version.py
+++ b/python/pyspark/version.py
@@ -16,4 +16,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__: str = "3.3.2+affirm.dev6"
+__version__: str = "3.3.2+affirm.dev8"

--- a/python/pyspark/version.py
+++ b/python/pyspark/version.py
@@ -16,4 +16,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__: str = "3.3.2+affirm.dev10"
+__version__: str = "2815!3.3.2+affirm.0"

--- a/python/setup.py
+++ b/python/setup.py
@@ -77,6 +77,7 @@ SCRIPTS_PATH = os.path.join(SPARK_HOME, "bin")
 USER_SCRIPTS_PATH = os.path.join(SPARK_HOME, "sbin")
 DATA_PATH = os.path.join(SPARK_HOME, "data")
 LICENSES_PATH = os.path.join(SPARK_HOME, "licenses")
+DOCKER_PATH = os.path.join(SPARK_HOME, "resource-managers/kubernetes/docker/src/main/dockerfiles/spark")
 
 SCRIPTS_TARGET = os.path.join(TEMP_PATH, "bin")
 USER_SCRIPTS_TARGET = os.path.join(TEMP_PATH, "sbin")
@@ -84,7 +85,7 @@ JARS_TARGET = os.path.join(TEMP_PATH, "jars")
 EXAMPLES_TARGET = os.path.join(TEMP_PATH, "examples")
 DATA_TARGET = os.path.join(TEMP_PATH, "data")
 LICENSES_TARGET = os.path.join(TEMP_PATH, "licenses")
-
+DOCKER_TARGET = os.path.join(TEMP_PATH, "k8s")
 # Check and see if we are under the spark path in which case we need to build the symlink farm.
 # This is important because we only want to build the symlink farm while under Spark otherwise we
 # want to use the symlink farm. And if the symlink farm exists under while under Spark (e.g. a
@@ -168,6 +169,7 @@ try:
             os.symlink(EXAMPLES_PATH, EXAMPLES_TARGET)
             os.symlink(DATA_PATH, DATA_TARGET)
             os.symlink(LICENSES_PATH, LICENSES_TARGET)
+            os.symlink(DOCKER_PATH, DOCKER_TARGET)
         else:
             # For windows fall back to the slower copytree
             copytree(JARS_PATH, JARS_TARGET)
@@ -176,6 +178,7 @@ try:
             copytree(EXAMPLES_PATH, EXAMPLES_TARGET)
             copytree(DATA_PATH, DATA_TARGET)
             copytree(LICENSES_PATH, LICENSES_TARGET)
+            copytree(DOCKER_PATH, DOCKER_TARGET)
     else:
         # If we are not inside of SPARK_HOME verify we have the required symlink farm
         if not os.path.exists(JARS_TARGET):
@@ -219,6 +222,7 @@ try:
                   'pyspark.streaming',
                   'pyspark.bin',
                   'pyspark.sbin',
+                  'pyspark.k8s',
                   'pyspark.jars',
                   'pyspark.pandas',
                   'pyspark.pandas.data_type_ops',
@@ -238,6 +242,7 @@ try:
         package_dir={
             'pyspark.jars': 'deps/jars',
             'pyspark.bin': 'deps/bin',
+            'pyspark.k8s': 'deps/k8s',
             'pyspark.sbin': 'deps/sbin',
             'pyspark.python.lib': 'lib',
             'pyspark.data': 'deps/data',
@@ -247,6 +252,7 @@ try:
         package_data={
             'pyspark.jars': ['*.jar'],
             'pyspark.bin': ['*'],
+            'pyspark.k8s': ['*'],
             'pyspark.sbin': ['spark-config.sh', 'spark-daemon.sh',
                              'start-history-server.sh',
                              'stop-history-server.sh', ],
@@ -299,6 +305,7 @@ finally:
             os.remove(os.path.join(TEMP_PATH, "examples"))
             os.remove(os.path.join(TEMP_PATH, "data"))
             os.remove(os.path.join(TEMP_PATH, "licenses"))
+            os.remove(os.path.join(TEMP_PATH, "k8s"))
         else:
             rmtree(os.path.join(TEMP_PATH, "jars"))
             rmtree(os.path.join(TEMP_PATH, "bin"))
@@ -306,4 +313,5 @@ finally:
             rmtree(os.path.join(TEMP_PATH, "examples"))
             rmtree(os.path.join(TEMP_PATH, "data"))
             rmtree(os.path.join(TEMP_PATH, "licenses"))
+            rmtree(os.path.join(TEMP_PATH, "k8s"))
         os.rmdir(TEMP_PATH)

--- a/python/setup.py
+++ b/python/setup.py
@@ -77,8 +77,7 @@ SCRIPTS_PATH = os.path.join(SPARK_HOME, "bin")
 USER_SCRIPTS_PATH = os.path.join(SPARK_HOME, "sbin")
 DATA_PATH = os.path.join(SPARK_HOME, "data")
 LICENSES_PATH = os.path.join(SPARK_HOME, "licenses")
-DOCKER_PATH = os.path.join(SPARK_HOME, 
-                           "resource-managers/kubernetes/docker/src/main/dockerfiles/spark")
+DOCKER_PATH = os.path.join(SPARK_HOME, "resource-managers/kubernetes/docker/src/main/dockerfiles/spark")
 
 SCRIPTS_TARGET = os.path.join(TEMP_PATH, "bin")
 USER_SCRIPTS_TARGET = os.path.join(TEMP_PATH, "sbin")

--- a/python/setup.py
+++ b/python/setup.py
@@ -77,7 +77,8 @@ SCRIPTS_PATH = os.path.join(SPARK_HOME, "bin")
 USER_SCRIPTS_PATH = os.path.join(SPARK_HOME, "sbin")
 DATA_PATH = os.path.join(SPARK_HOME, "data")
 LICENSES_PATH = os.path.join(SPARK_HOME, "licenses")
-DOCKER_PATH = os.path.join(SPARK_HOME, "resource-managers/kubernetes/docker/src/main/dockerfiles/spark")
+DOCKER_PATH = os.path.join(SPARK_HOME, 
+                           "resource-managers/kubernetes/docker/src/main/dockerfiles/spark")
 
 SCRIPTS_TARGET = os.path.join(TEMP_PATH, "bin")
 USER_SCRIPTS_TARGET = os.path.join(TEMP_PATH, "sbin")

--- a/resource-managers/kubernetes/core/pom.xml
+++ b/resource-managers/kubernetes/core/pom.xml
@@ -95,6 +95,22 @@
       </exclusions>
     </dependency>
 
+    <dependency>
+      <groupId>io.kubernetes</groupId>
+      <artifactId>client-java</artifactId>
+      <version>8.0.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.dataformat</groupId>
+          <artifactId>jackson-dataformat-yaml</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
     <!-- Required by kubernetes-client but we exclude it -->
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>

--- a/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/entrypoint.sh
+++ b/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/entrypoint.sh
@@ -107,4 +107,4 @@ case "$1" in
 esac
 
 # Execute the container CMD under tini for better hygiene
-exec /usr/bin/tini -s -- "${CMD[@]}"
+exec /tini -s -- "${CMD[@]}"


### PR DESCRIPTION
First release of spark 3.3.2 for Affirm. This mainly amends the official spark release to:
- use specific build command for Affirm's spark k8s distribution
- adds jars in `pom.xml` file to be packaged in distribution
- sets up spark k8s entrypoint in build