### PR TITLE
Reduce size of 3.3.2 build without aws bundle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -325,6 +325,10 @@
       </snapshots>
     </repository>
     <repository>
+      <id>tabular-releases</id>
+      <url>https://tabular-repository-public.s3.amazonaws.com/releases</url>
+    </repository>
+    <repository>
       <!--
         This is used as a fallback when the first try fails.
       -->
@@ -418,11 +422,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>software.amazon.awssdk</groupId>
-      <artifactId>bundle</artifactId>
-      <version>2.20.83</version>
-    </dependency>
-    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-aws</artifactId>
       <version>3.3.2</version>
@@ -432,6 +431,11 @@
       <artifactId>iceberg-spark-runtime-3.3_2.12</artifactId>
       <version>1.3.0</version>
       <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.tabular</groupId>
+      <artifactId>tabular-client-runtime</artifactId>
+      <version>1.18.4</version>
     </dependency>
   </dependencies>
   <dependencyManagement>

--- a/python/pyspark/version.py
+++ b/python/pyspark/version.py
@@ -16,4 +16,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__: str = "2815!3.3.2+affirm.0"
+__version__: str = "3.3.2+affirm.dev11"

--- a/python/pyspark/version.py
+++ b/python/pyspark/version.py
@@ -16,4 +16,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__: str = "3.3.2+affirm.dev11"
+__version__: str = "2815!3.3.2+affirm.1"


### PR DESCRIPTION
Use `tabular-client-runtime.jar` instead of `aws-bundle` to minimize size of distribution