### PR TITLE
[iceberg] upgrade iceberg spark runtime to 1.4.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -437,6 +437,11 @@
       <artifactId>mysql-connector-java</artifactId>
       <version>8.0.27</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.iceberg</groupId>
+      <artifactId>iceberg-aws-bundle</artifactId>
+      <version>1.4.2</version>
+    </dependency>
   </dependencies>
   <dependencyManagement>
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -429,13 +429,8 @@
     <dependency>
       <groupId>org.apache.iceberg</groupId>
       <artifactId>iceberg-spark-runtime-3.3_2.12</artifactId>
-      <version>1.3.0</version>
+      <version>1.4.2</version>
       <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.tabular</groupId>
-      <artifactId>tabular-client-runtime</artifactId>
-      <version>1.18.4</version>
     </dependency>
     <dependency>
       <groupId>mysql</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -325,10 +325,6 @@
       </snapshots>
     </repository>
     <repository>
-      <id>tabular-releases</id>
-      <url>https://tabular-repository-public.s3.amazonaws.com/releases</url>
-    </repository>
-    <repository>
       <!--
         This is used as a fallback when the first try fails.
       -->
@@ -441,6 +437,11 @@
       <groupId>org.apache.iceberg</groupId>
       <artifactId>iceberg-aws-bundle</artifactId>
       <version>1.4.2</version>
+    </dependency>
+    <dependency>
+      <groupId>mysql</groupId>
+      <artifactId>mysql-connector-java</artifactId>
+      <version>8.0.27</version>
     </dependency>
   </dependencies>
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -438,11 +438,6 @@
       <artifactId>iceberg-aws-bundle</artifactId>
       <version>1.4.2</version>
     </dependency>
-    <dependency>
-      <groupId>mysql</groupId>
-      <artifactId>mysql-connector-java</artifactId>
-      <version>8.0.27</version>
-    </dependency>
   </dependencies>
   <dependencyManagement>
     <dependencies>

--- a/python/pyspark/version.py
+++ b/python/pyspark/version.py
@@ -16,4 +16,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__: str = "2815!3.3.2+affirm.dev19"
+__version__: str = "2815!3.3.2+affirm.2"

--- a/python/pyspark/version.py
+++ b/python/pyspark/version.py
@@ -16,4 +16,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__: str = "2815!3.3.2+affirm.1"
+__version__: str = "2815!3.3.2+affirm.dev18"

--- a/python/pyspark/version.py
+++ b/python/pyspark/version.py
@@ -16,4 +16,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__: str = "2815!3.3.2+affirm.dev18"
+__version__: str = "2815!3.3.2+affirm.dev19"


### PR DESCRIPTION
Decreases build size from 535 mb to 517 mb

- Upgrades iceberg / spark runtime to 1.4.2
- Adds needed `iceberg-aws-bundle`
- Removes unneeded `tabular-client-runtime`
