### PR TITLE
Patch iceberg-spark-runtime 1.8.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
     <log4j.version>2.20.0</log4j.version>
     <iceberg.version>1.8.1</iceberg.version>
     <!-- make sure to update IsolatedClientLoader whenever this version is changed -->
-    <hadoop.version>3.3.2</hadoop.version>
+    <hadoop.version>3.3.4</hadoop.version>
     <!-- SPARK-41247: When updating `protobuf.version`, also need to update `protoVersion` in `SparkBuild.scala` -->
     <protobuf.version>3.23.4</protobuf.version>
     <protoc-jar-maven-plugin.version>3.11.4</protoc-jar-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -440,7 +440,7 @@
     <dependency>
       <groupId>org.apache.iceberg</groupId>
       <artifactId>iceberg-spark-runtime-3.5_2.12</artifactId>
-      <version>${iceberg.version}</version>
+      <version>${iceberg.version}-PATCH</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
     <log4j.version>2.20.0</log4j.version>
     <iceberg.version>1.8.1</iceberg.version>
     <!-- make sure to update IsolatedClientLoader whenever this version is changed -->
-    <hadoop.version>3.2.4</hadoop.version>
+    <hadoop.version>3.3.2</hadoop.version>
     <!-- SPARK-41247: When updating `protobuf.version`, also need to update `protoVersion` in `SparkBuild.scala` -->
     <protobuf.version>3.23.4</protobuf.version>
     <protoc-jar-maven-plugin.version>3.11.4</protoc-jar-maven-plugin.version>

--- a/python/pyspark/version.py
+++ b/python/pyspark/version.py
@@ -16,4 +16,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__: str = "2815!3.5.4+affirm.dev10"
+__version__: str = "2815!3.5.4+affirm.dev9"

--- a/python/pyspark/version.py
+++ b/python/pyspark/version.py
@@ -16,4 +16,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__: str = "2815!3.5.4+affirm.dev11"
+__version__: str = "2815!3.5.4+affirm.3"

--- a/python/pyspark/version.py
+++ b/python/pyspark/version.py
@@ -16,4 +16,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__: str = "2815!3.5.4+affirm.2"
+__version__: str = "2815!3.5.4+affirm.dev11"

--- a/python/pyspark/version.py
+++ b/python/pyspark/version.py
@@ -16,4 +16,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__: str = "2815!3.5.4+affirm.dev9"
+__version__: str = "2815!3.5.4+affirm.2"


### PR DESCRIPTION
Patching iceberg-spark-runtime 1.8.1. 

The core iceberg-core library has a bug that is capable of corrupting tables, as described in [Iceberg Issue 12792](https://github.com/apache/iceberg/issues/12792#issuecomment-2804324419). This patched iceberg jar contains a fix backported to iceberg 1.8.1. 

Documentation on building and installing this patched iceberg-spark-runtime is [available here](https://www.notion.so/affirm/How-to-upgrade-PySpark-to-3-5-x-19340e54ae388015bb68e94a8389d526#19340e54ae3880cfa2bfee33e8f75c6c).

Also reverts affirm.dev10 and affirm.dev11, which contained changes that were not yet included in production releases. 



### How was this patch tested?
This patch was tested via data-replication DAG runs in Alpine and stage. 


