### PR TITLE
Patch Iceberg Client to Prevent Table Metadata Corruption

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -440,7 +440,7 @@
     <dependency>
       <groupId>org.apache.iceberg</groupId>
       <artifactId>iceberg-spark-runtime-3.5_2.12</artifactId>
-      <version>${iceberg.version}-PATCH</version>
+      <version>${iceberg.version}-PATCH.1</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>

--- a/python/pyspark/version.py
+++ b/python/pyspark/version.py
@@ -16,4 +16,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__: str = "2815!3.5.4+affirm.3"
+__version__: str = "2815!3.5.4+affirm.4"


### PR DESCRIPTION
This change patches iceberg-spark-runtime to prevent 5xx Http retries from corrupting table metadata during commit operations. 

See Affirm/iceberg PR for details of patch: https://github.com/Affirm/iceberg/pull/1
See [How to Build Iceberg](https://www.notion.so/affirm/How-to-Build-Iceberg-and-Bundle-in-Spark-Locally-21c40e54ae3880f2a1dbe2e93ae00956) for instructions on building the patched iceberg jar, and installing in local Maven to build spark w/ the patched jar. 
